### PR TITLE
support ubuntu & alpine base docker image

### DIFF
--- a/stack-docker/pom.xml
+++ b/stack-docker/pom.xml
@@ -139,6 +139,52 @@
                 </configuration>
               </execution>
 
+              <execution>
+                <id>base-image-alpine</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <configuration>
+                  <dockerDirectory>${project.build.directory}/docker-filtered/alpine</dockerDirectory>
+                  <imageName>vertx/vertx3-alpine</imageName>
+                  <!-- During release, check the pulled java version, and update if needed -->
+
+                  <!-- Tags should only be enabled during release -->
+                  <!--<imageTags>-->
+                  <!--<tag>${project.version}</tag>-->
+                  <!--</imageTags>-->
+                  <resources>
+                    <resource>
+                      <targetPath>/usr/local</targetPath>
+                      <directory>${project.build.directory}/work</directory>
+                    </resource>
+                  </resources>
+                  <!-- configuration to push the image into docker hub - requires credentials in the Maven settings -->
+                  <serverId>docker-hub</serverId>
+                  <registryUrl>https://index.docker.io/v1/</registryUrl>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>exec-alpine</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <configuration>
+                  <dockerDirectory>${project.basedir}/src/main/docker/exec/alpine</dockerDirectory>
+                  <imageName>vertx/vertx3-alpine-exec</imageName>
+                  <!-- Tags should only be enabled during release -->
+                  <!--<imageTags>-->
+                  <!--<tag>${project.version}</tag>-->
+                  <!--</imageTags>-->
+                  <!-- configuration to push the image into docker hub - requires credentials in the Maven settings -->
+                  <serverId>docker-hub</serverId>
+                  <registryUrl>https://index.docker.io/v1/</registryUrl>
+                </configuration>
+              </execution>
+
             </executions>
           </plugin>
         </plugins>

--- a/stack-docker/src/main/docker/base/alpine/Dockerfile
+++ b/stack-docker/src/main/docker/base/alpine/Dockerfile
@@ -1,10 +1,11 @@
 # A base Dockerfile for Vert.x 3
 
-FROM java:8u91
+FROM java:8u92-jre-alpine
 
 MAINTAINER Clement Escoffier <clement@apache.org>
 
 COPY ./usr /usr/
+RUN apk add --update bash && rm -rf /var/cache/apk/*
 RUN chmod +x /usr/local/vertx/bin/vertx
 
 # Set path

--- a/stack-docker/src/main/docker/exec/alpine/Dockerfile
+++ b/stack-docker/src/main/docker/exec/alpine/Dockerfile
@@ -1,0 +1,7 @@
+# A simple example showing how the vertx image can be used.
+
+FROM vertx/vertx3-alpine
+
+# vertx is added to the PATH in vertx/vertx3
+ENTRYPOINT ["vertx"]
+CMD ["--help"]


### PR DESCRIPTION
Hello! Vertx3 docker images is only served alpine based image. Alpine based image is small. But alpine has some problem about shared library.

```
Caused by: java.lang.UnsatisfiedLinkError: /tmp/snappy-1.0.5-libsnappyjava.so: Error loading shared library libstdc++.so.6: No such file or directory (needed by /tmp/snappy-1.0.5-libsnappyjava.so)
```

Most official docker images support ubuntu(or centos) and alpine. (You can find at https://hub.docker.com/_/java/) It's better to use both base image. So I've added both image build setting. Please review this! Thanks.