### PR TITLE
Docker: use openjdk:8-jre-alpine

### DIFF
--- a/stack-docker/src/main/asciidoc/index.adoc
+++ b/stack-docker/src/main/asciidoc/index.adoc
@@ -557,7 +557,7 @@ First, be sure your application is packaged as a _fat jar_. Then, use the follow
 
 [source]
 ----
-FROM java:8u77-jre-alpine                                           <1>
+FROM openjdk:8-jre-alpine                                           <1>
 
 ENV VERTICLE_FILE hello-verticle-fatjar-3.0.0-SNAPSHOT-fat.jar      <2>
 

--- a/stack-docker/src/main/docker/base/Dockerfile
+++ b/stack-docker/src/main/docker/base/Dockerfile
@@ -1,6 +1,6 @@
 # A base Dockerfile for Vert.x 3
 
-FROM java:8u92-jre-alpine
+FROM openjdk:8-jre-alpine
 
 MAINTAINER Clement Escoffier <clement@apache.org>
 


### PR DESCRIPTION
java:8-jre-alpine is deprecated