### PR TITLE
Added a stack-definition for Scala as request in #27

### DIFF
--- a/stack-manager/pom.xml
+++ b/stack-manager/pom.xml
@@ -211,6 +211,22 @@
               </arguments>
             </configuration>
           </execution>
+	  <execution>
+            <id>build-scala-stack</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <mainClass>io.vertx.core.Launcher</mainClass>
+              <arguments>
+                <argument>resolve</argument>
+                <argument>${project.basedir}/target/vertx-stack/vertx-stack-scala.json</argument>
+                <argument>--dir=${project.basedir}/target/scala-lib</argument>
+                <argument>--no-cache</argument>
+              </arguments>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -288,6 +304,21 @@
               <appendAssemblyId>true</appendAssemblyId>
               <descriptors>
                 <descriptor>src/main/assembly/stack-full.xml</descriptor>
+              </descriptors>
+            </configuration>
+            <phase>package</phase>
+          </execution>
+
+          <execution>
+            <id>vertx-stack-scala</id>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <finalName>${finalName}</finalName>
+              <appendAssemblyId>true</appendAssemblyId>
+              <descriptors>
+                <descriptor>src/main/assembly/stack-scala.xml</descriptor>
               </descriptors>
             </configuration>
             <phase>package</phase>

--- a/stack-manager/src/main/assembly/stack-scala.xml
+++ b/stack-manager/src/main/assembly/stack-scala.xml
@@ -1,0 +1,77 @@
+<!--
+  ~  Copyright (c) 2011-2015 The original author or authors
+  ~
+  ~  All rights reserved. This program and the accompanying materials
+  ~  are made available under the terms of the Eclipse Public License v1.0
+  ~  and Apache License v2.0 which accompanies this distribution.
+  ~
+  ~       The Eclipse Public License is available at
+  ~       http://www.eclipse.org/legal/epl-v10.html
+  ~
+  ~       The Apache License v2.0 is available at
+  ~       http://www.opensource.org/licenses/apache2.0.php
+  ~
+  ~  You may elect to redistribute this code under either of these licenses.
+  -->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+
+  <id>stack-scala</id>
+  <formats>
+    <format>dir</format>
+    <format>tar.gz</format>
+    <format>zip</format>
+  </formats>
+
+
+  <!-- we use a "stable" base directory, without the version to ease testability -->
+  <baseDirectory>vertx</baseDirectory>
+
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}/target/scala-lib</directory>
+      <outputDirectory>/lib/</outputDirectory>
+    </fileSet>
+
+    <fileSet>
+      <directory>${project.basedir}/src/main/packaging</directory>
+      <outputDirectory>.</outputDirectory>
+    </fileSet>
+
+    <fileSet>
+      <directory>${project.basedir}/target/vertx-stack-scala</directory>
+      <includes>
+        <include>vertx-stack-scala.json</include>
+      </includes>
+      <outputDirectory>.</outputDirectory>
+    </fileSet>
+  </fileSets>
+
+  <dependencySets>
+    <dependencySet>
+      <useProjectArtifact>false</useProjectArtifact>
+      <outputDirectory>/conf/</outputDirectory>
+      <includes>
+        <include>io.vertx:vertx-hazelcast</include>
+      </includes>
+      <scope>provided</scope>
+      <unpack>true</unpack>
+      <unpackOptions>
+        <includes>
+          <include>default-cluster.xml</include>
+        </includes>
+      </unpackOptions>
+    </dependencySet>
+
+    <dependencySet>
+      <useProjectArtifact>true</useProjectArtifact>
+      <outputDirectory>/lib/</outputDirectory>
+      <includes>
+        <include>${project.groupId}:${project.artifactId}:jar:${project.version}</include>
+      </includes>
+    </dependencySet>
+  </dependencySets>
+
+</assembly>

--- a/stack-manager/src/main/descriptor/vertx-stack-scala.json
+++ b/stack-manager/src/main/descriptor/vertx-stack-scala.json
@@ -1,0 +1,352 @@
+//
+// vert.x stack descriptor
+//
+// To add a dependency:
+// - if the dependency is already listed, just set `included` to `true`
+// - if not, add the dependency using the Maven coordinates, and set `included` to `true`
+//
+// You can also set `exclusions` and whether or not the dependency need to resolve its transitive dependencies.
+//
+// Then launch the resolution process with: vertx resolve --dir=lib --stack=./vertx-vertx.json
+//
+// To remove a dependency:
+// - either remove the dependency declaration or just toggled the `included` value. Then launch the resolution process.
+//
+{
+  "variables": {
+    "vertx.version": "${vertx.version}",
+    "tcnative.version": "1.1.33.Fork26"
+  },
+  "dependencies": [
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-core",
+      "version": "\${vertx.version}",
+      "included": true
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-lang-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": true
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-hazelcast",
+      "version": "\${vertx.version}",
+      "included": true
+    },
+    {
+      "groupId": "io.netty",
+      "artifactId": "netty-tcnative-boringssl-static",
+      "version": "\${tcnative.version}",
+      "included": true
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-web-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": true
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-web-common-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": true
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-amqp-bridge-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-mqtt-server-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-sql-common-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-bridge-common-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-jdbc-client-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-mongo-client-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-mongo-service-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-auth-common-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-auth-shiro-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-auth-htdigest-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-auth-oauth2-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-auth-mongo-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-auth-jwt-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-auth-jdbc-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-web-client-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-sockjs-service-proxy-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-web-templ-freemarker-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-web-templ-handlebars-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-web-templ-jade-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-web-templ-mvel-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-web-templ-pebble-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-web-templ-thymeleaf-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-mysql-postgresql-client-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-mail-client-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-rabbitmq-client-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-redis-client-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-stomp-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-tcp-eventbus-bridge-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-dropwizard-metrics-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-hawkular-metrics-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-shell-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-kafka-client-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-service-discovery-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-service-discovery-backend-zookeeper-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-service-discovery-backend-redis-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-service-discovery-bridge-consul-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-service-discovery-bridge-docker-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-service-discovery-bridge-docker-links-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-service-discovery-bridge-kubernetes-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-service-discovery-bridge-zookeeper-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-circuit-breaker-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-config-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-config-git-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-config-hocon-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-config-kubernetes-configmap-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-config-redis-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-config-spring-config-server-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-config-yaml-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
+      "artifactId": "vertx-config-zookeeper-scala_2.12",
+      "version": "\${vertx.version}",
+      "included": false
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a vertx-stack-scala.json and some assemblies based on it.
I deliberately only included the most basic modules by default (vertx-web, vertx-hazelcast and related scala modules). All others are available but not included by default.
