### PR TITLE
correct links of docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Examples of docker image usages are in https://github.com/vert-x3/vertx-examples
 
 #### Pushing Docker image to Docker Hub
 
-The images can be pushed to Docker Hub. Before, be sure you are in the _vertx_ organisation on docker hub (https://registry.hub.docker.com/repos/vertx/). Then, add your credentials into `~/.m2/settings.xml`:
+The images can be pushed to Docker Hub. Before, be sure you are in the _vertx_ organisation on docker hub (https://hub.docker.com/u/vertx/). Then, add your credentials into `~/.m2/settings.xml`:
 
 ```
 <server>
@@ -89,13 +89,13 @@ mvn docker:push
 ### Adding a new module to the stack
 
 1. Add it to `vertx-dependencies` (open the project, add it to the `pom.xml`, install, commit and push)
-2. Add it to `stack-depchain/pom.xml` (open the project, add the dependency, without the version (inherited from 
+2. Add it to `stack-depchain/pom.xml` (open the project, add the dependency, without the version (inherited from
 vertx-dependencies))
 3. Add it in the stack manager:
   * Open `./stack-manager/src/main/descriptor/vertx-stack.json`
   * Add the dependency. If the dependency must be embedded in the _min_ distribution, set `included` to `true`. So forget to use the `\${version}`.
   * Open `./stack-manager/src/main/descriptor/vertx-stack-full.json`
-  * Add the dependency. If the dependency must be embedded in the _full_ distribution, set `included` to `true`. So forget to use the `\${version}`.  
+  * Add the dependency. If the dependency must be embedded in the _full_ distribution, set `included` to `true`. So forget to use the `\${version}`.
 4. Add it to the doc distribution:
   * Open `./stack-docs/pom.xml`
   * Add the `docs` dependency (the using `<classifier>docs</classifier>` and `<type>zip</type>`)
@@ -107,6 +107,6 @@ vertx-dependencies))
 </copy>
 ```
   * Save the `pom.xml` file
-4. Build (`mvn clean install` from the root).  
+4. Build (`mvn clean install` from the root).
 
-  
+

--- a/stack-docker/src/main/asciidoc/index.adoc
+++ b/stack-docker/src/main/asciidoc/index.adoc
@@ -5,14 +5,14 @@ Execute Vert.x applications in Docker containers.
 == Introduction
 
 https://www.docker.com/[Docker] lets you deploy applications inside lightweight and isolated software containers.
-Applications run side by side in isolated Linux containers. If you never used Docker before check this online https://www.docker.com/tryit/[tutorial].
+Applications run side by side in isolated Linux containers. If you never used Docker before check this online https://docs.docker.com/get-started/[tutorial].
 
 Vert.x provides Docker images that you can use to run your applications. Two Docker images are provided:
 
 * `vertx/vertx3` is the base image you need to extend to run your own application
 * `vertx/vertx3-exec` is providing the `vertx` command to your system without having to install `vert.x` yourself.
 
-The images are available from https://registry.hub.docker.com/repos/vertx/[Docker Hub].
+The images are available from https://hub.docker.com/u/vertx/[Docker Hub].
 
 This guide presents how to use these two images but also how to automate Docker image creation using Maven, generate
 Fabric8 metadata and use _fat jars_.
@@ -535,7 +535,7 @@ For instance:
 [source, shell]
 ----
 > docker run -i -t vertx/vertx3-exec -version
-3.0.0-SNAPSHOT
+3.4.2-SNAPSHOT
 ----
 
 To run a verticle:


### PR DESCRIPTION
1. change vertx profile link in docker hub because the old one is broken
2. change the docker tutorial because the old one will be redirected

Also , I think should change the output version in run  `docker run -i -t vertx/vertx3-exec -version`