### PR TITLE
Add new module vertx-micrometer-metrics

### DIFF
--- a/stack-depchain/pom.xml
+++ b/stack-depchain/pom.xml
@@ -72,6 +72,10 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
+      <artifactId>vertx-micrometer-metrics</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-reactive-streams</artifactId>
     </dependency>
     <dependency>

--- a/stack-docs/pom.xml
+++ b/stack-docs/pom.xml
@@ -184,6 +184,20 @@
 
     <dependency>
       <groupId>io.vertx</groupId>
+      <artifactId>vertx-micrometer-metrics</artifactId>
+      <version>${vertx.docs.version}</version>
+      <classifier>docs</classifier>
+      <type>zip</type>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-micrometer-metrics</artifactId>
+      <version>${vertx.docs.version}</version>
+      <classifier>sources</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-mail-client</artifactId>
       <version>${vertx.docs.version}</version>
       <classifier>docs</classifier>
@@ -1302,6 +1316,9 @@
                 </copy>
                 <copy todir="${project.build.directory}/docs/">
                   <fileset dir="${project.build.directory}/work/vertx-lang-ceylon-stack-docs-zip"/>
+                </copy>
+                <copy todir="${project.build.directory}/docs/vertx-micrometer-metrics/">
+                  <fileset dir="${project.build.directory}/work/vertx-micrometer-metrics-docs-zip"/>
                 </copy>
                 <copy todir="${project.build.directory}/docs/vertx-stack-manager/">
                   <fileset dir="${project.build.directory}/work/vertx-stack-manager-docs-zip"/>

--- a/stack-manager/src/main/descriptor/vertx-stack-full.json
+++ b/stack-manager/src/main/descriptor/vertx-stack-full.json
@@ -100,6 +100,12 @@
     },
     {
       "groupId": "io.vertx",
+      "artifactId": "vertx-micrometer-metrics",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
       "artifactId": "vertx-maven-service-factory",
       "version": "\${vertx.version}",
       "included": true

--- a/stack-manager/src/main/descriptor/vertx-stack.json
+++ b/stack-manager/src/main/descriptor/vertx-stack.json
@@ -100,6 +100,12 @@
     },
     {
       "groupId": "io.vertx",
+      "artifactId": "vertx-micrometer-metrics",
+      "version": "\${vertx.version}",
+      "included": false
+    },
+    {
+      "groupId": "io.vertx",
       "artifactId": "vertx-maven-service-factory",
       "version": "\${vertx.version}",
       "included": false


### PR DESCRIPTION
Dependant on https://github.com/vert-x3/vertx-dependencies/pull/9 (which should be merged first) and snapshots deployment by CI

Note: tests are failing but seem unrelated to the component being added:

```
Tests run: 5, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 258.406 sec <<< FAILURE! - in io.vertx.stack.VertxStacksTest
testConvergence(io.vertx.stack.VertxStacksTest)  Time elapsed: 150.457 sec  <<< ERROR!
io.vertx.stack.model.DependencyConflictException: Conflict detected for artifact org.apache.zookeeper:zookeeper:jar - version 3.4.9 was already selected while io.vertx:vertx-kafka-client:jar:3.5.1-SNAPSHOT depends on version 3.4.10
	at io.vertx.stack.model.StackResolution.lambda$resolve$4(StackResolution.java:177)
```