### PR TITLE
Fix wrong artifactId of dependency chain example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ the base stack:
 ~~~~
 <dependency>
   <groupId>io.vertx</groupId>
-  <artifactId>stack-depchain</artifactId>
+  <artifactId>vertx-stack-depchain</artifactId>
   <version>3.5.1</version>
   <type>pom</type>
 </dependency>


### PR DESCRIPTION
Fix wrong artifactId of dependency chain example in README.md, it is missing a `vertx-`.