### PR TITLE
add vertx-web-openapi-router to the stack

### DIFF
--- a/stack-depchain/pom.xml
+++ b/stack-depchain/pom.xml
@@ -184,6 +184,10 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-openapi-router</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-web-sstore-cookie</artifactId>
     </dependency>
     <dependency>

--- a/stack-docs/pom.xml
+++ b/stack-docs/pom.xml
@@ -843,6 +843,20 @@
 
     <dependency>
       <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-openapi-router</artifactId>
+      <version>${vertx.docs.version}</version>
+      <classifier>docs</classifier>
+      <type>zip</type>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-openapi-router</artifactId>
+      <version>${vertx.docs.version}</version>
+      <classifier>sources</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-web-api-service</artifactId>
       <version>${vertx.docs.version}</version>
       <classifier>docs</classifier>
@@ -1832,6 +1846,9 @@
                 </copy>
                 <copy todir="${project.build.directory}/docs/vertx-web-openapi/">
                   <fileset dir="${project.build.directory}/work/vertx-web-openapi-docs-zip"/>
+                </copy>
+                <copy todir="${project.build.directory}/docs/vertx-web-openapi-router/">
+                  <fileset dir="${project.build.directory}/work/vertx-web-openapi-router-docs-zip"/>
                 </copy>
                 <copy todir="${project.build.directory}/docs/vertx-web-api-service/">
                   <fileset dir="${project.build.directory}/work/vertx-web-api-service-docs-zip"/>


### PR DESCRIPTION
Motivation:

`vertx-web-openapi-router` is a new package in vertx-web and needs to be added to the stack