### PR TITLE
Detailed dependency path for DependencyConflictException

### DIFF
--- a/stack-manager/src/main/java/io/vertx/stack/model/Artifact.java
+++ b/stack-manager/src/main/java/io/vertx/stack/model/Artifact.java
@@ -20,12 +20,12 @@ public class Artifact extends AbstractArtifact {
     this(new DefaultArtifact(coordinates), via);
   }
 
-  public Artifact(String groupId, String artifactId, String classifier, String extension, String version) {
-    this(groupId + ":" + artifactId + ":" + extension + ":" + classifier + ":" + version, null);
+  public Artifact(String groupId, String artifactId, String classifier, String extension, String version, Artifact via) {
+    this(groupId + ":" + artifactId + ":" + extension + ":" + classifier + ":" + version, via);
   }
 
-  public Artifact(String groupId, String artifactId, String extension, String version) {
-    this(groupId + ":" + artifactId + ":" + extension + ":" + version, null);
+  public Artifact(String groupId, String artifactId, String extension, String version, Artifact via) {
+    this(groupId + ":" + artifactId + ":" + extension + ":" + version, via);
   }
 
   public Artifact(org.eclipse.aether.artifact.Artifact fromArtifact, Artifact via) {

--- a/stack-manager/src/main/java/io/vertx/stack/model/Artifact.java
+++ b/stack-manager/src/main/java/io/vertx/stack/model/Artifact.java
@@ -1,94 +1,36 @@
 package io.vertx.stack.model;
 
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.aether.artifact.AbstractArtifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 
 import java.io.File;
-import java.util.*;
+import java.util.Map;
+import java.util.Objects;
 
 public class Artifact extends AbstractArtifact {
 
   private org.eclipse.aether.artifact.Artifact internal;
-  private HashSet<Artifact> via;
-  private static final Map<String, Artifact> globalArtifacts = new HashMap<>();
+  private final Artifact via;
 
-  /**
-   * Use {@link #artifact(String)} or {@link #artifact(String, Artifact...)}.
-   */
-  private Artifact() {
-    // use static artifact(String) or artifact(String, Artifact...) methods
+  public Artifact(String coordinates) {
+    this(coordinates, null);
   }
 
-  private Artifact(String coordinates, Artifact... via) {
+  public Artifact(String coordinates, Artifact via) {
     this(new DefaultArtifact(coordinates), via);
   }
 
-  private Artifact(org.eclipse.aether.artifact.Artifact fromArtifact, Artifact... via) {
+  public Artifact(String groupId, String artifactId, String classifier, String extension, String version) {
+    this(groupId + ":" + artifactId + ":" + extension + ":" + classifier + ":" + version, null);
+  }
+
+  public Artifact(String groupId, String artifactId, String extension, String version) {
+    this(groupId + ":" + artifactId + ":" + extension + ":" + version, null);
+  }
+
+  public Artifact(org.eclipse.aether.artifact.Artifact fromArtifact, Artifact via) {
     internal = fromArtifact;
-    this.via = new HashSet<>(Arrays.asList(via));
-  }
-
-  public static Artifact artifact(String coordinates) {
-    return artifact(coordinates, new Artifact[]{});
-  }
-
-  public static Artifact artifact(String groupId, String artifactId, String classifier, String extension, String version, Artifact... via) {
-    return artifact(groupId + ":" + artifactId + ":" + extension + ":" + classifier + ":" + version, via);
-  }
-
-  public static Artifact artifact(String groupId, String artifactId, String extension, String version, Artifact... via) {
-    return artifact(groupId + ":" + artifactId + ":" + extension + ":" + version, via);
-  }
-
-  public static Artifact artifact(String coordinates, Artifact... via) {
-    return globalArtifacts.merge(coordinates, new Artifact(coordinates, via), (a1, a2) -> a1.addVia(a2.via));
-  }
-
-  // TODO make via a single value instead of a collection
-  public static Artifact artifact(org.eclipse.aether.artifact.Artifact fromArtifact, Artifact... via) {
-    String coordinates = coordinates(fromArtifact);
-    return globalArtifacts.merge(coordinates, new Artifact(fromArtifact, via), (a1, a2) -> a1.addVia(a2.via));
-  }
-
-  /**
-   * Add more artifacts pointing to this.
-   */
-  public void addVia(Artifact... moreVia) {
-    addVia(Arrays.asList(moreVia));
-  }
-
-  /**
-   * Add more artifacts pointing to this.
-   */
-  public Artifact addVia(Collection<Artifact> moreVia) {
-    this.via.addAll(moreVia);
-    return this;
-  }
-
-  /**
-   * Renders the chain of artifacts that led to this artifact as String.
-   */
-  public static String renderChain(Artifact fromArtifact) {
-    return renderChain(fromArtifact, 0, new ArrayList<>());
-  }
-
-  private static String renderChain(Artifact fromArtifact, int level, List<String> acc) {
-    Optional<Artifact> maybeVia = fromArtifact.via.stream().findFirst();
-    if (maybeVia.isPresent()) {
-      Artifact via = maybeVia.get();
-      acc.add(0, coordinates(fromArtifact));
-      return renderChain(via, level + 1, acc);
-    } else {
-      StringBuilder chainBuilder = new StringBuilder(coordinates(fromArtifact));
-      for (int i = 0; i < acc.size(); i++) {
-        String indent = StringUtils.repeat("\t", i + 1);
-        chainBuilder
-          .append("\n")
-          .append(indent).append("\\-- ").append(acc.get(i));
-      }
-      return chainBuilder.toString();
-    }
+    this.via = via;
   }
 
   @Override
@@ -116,14 +58,6 @@ public class Artifact extends AbstractArtifact {
     return internal.getExtension();
   }
 
-  private static String coordinates(org.eclipse.aether.artifact.Artifact artifact) {
-    // <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>
-    return artifact.getGroupId() + ":" + artifact.getArtifactId()
-      + ":" + artifact.getExtension()
-      + (artifact.getClassifier().isEmpty() ? "" : ":" + artifact.getClassifier())
-      + ":" + artifact.getVersion();
-  }
-
   @Override
   public Artifact setFile(File file) {
     internal = internal.setFile(file);
@@ -140,6 +74,14 @@ public class Artifact extends AbstractArtifact {
     return internal.getProperties();
   }
 
+  public Artifact getVia() {
+    return this.via;
+  }
+
+  public String getCoordinates() {
+    return coordinates(this);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -152,5 +94,13 @@ public class Artifact extends AbstractArtifact {
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), internal, via);
+  }
+
+  private static String coordinates(org.eclipse.aether.artifact.Artifact artifact) {
+    // <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>
+    return artifact.getGroupId() + ":" + artifact.getArtifactId()
+      + ":" + artifact.getExtension()
+      + (artifact.getClassifier().isEmpty() ? "" : ":" + artifact.getClassifier())
+      + ":" + artifact.getVersion();
   }
 }

--- a/stack-manager/src/main/java/io/vertx/stack/model/Artifact.java
+++ b/stack-manager/src/main/java/io/vertx/stack/model/Artifact.java
@@ -45,6 +45,12 @@ public class Artifact extends AbstractArtifact {
     return globalArtifacts.merge(coordinates, new Artifact(coordinates, via), (a1, a2) -> a1.addVia(a2.via));
   }
 
+  // TODO make via a single value instead of a collection
+  public static Artifact artifact(org.eclipse.aether.artifact.Artifact fromArtifact, Artifact... via) {
+    String coordinates = coordinates(fromArtifact);
+    return globalArtifacts.merge(coordinates, new Artifact(fromArtifact, via), (a1, a2) -> a1.addVia(a2.via));
+  }
+
   /**
    * Add more artifacts pointing to this.
    */
@@ -71,10 +77,10 @@ public class Artifact extends AbstractArtifact {
     Optional<Artifact> maybeVia = fromArtifact.via.stream().findFirst();
     if (maybeVia.isPresent()) {
       Artifact via = maybeVia.get();
-      acc.add(0, fromArtifact.getCoordinates());
+      acc.add(0, coordinates(fromArtifact));
       return renderChain(via, level + 1, acc);
     } else {
-      StringBuilder chainBuilder = new StringBuilder(fromArtifact.getCoordinates());
+      StringBuilder chainBuilder = new StringBuilder(coordinates(fromArtifact));
       for (int i = 0; i < acc.size(); i++) {
         String indent = StringUtils.repeat("\t", i + 1);
         chainBuilder
@@ -110,15 +116,12 @@ public class Artifact extends AbstractArtifact {
     return internal.getExtension();
   }
 
-  /**
-   * @return the artifact coordinates in the form {@code <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>}
-   */
-  public String getCoordinates() {
+  private static String coordinates(org.eclipse.aether.artifact.Artifact artifact) {
     // <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>
-    return getGroupId() + ":" + getArtifactId()
-      + ":" + getExtension()
-      + (getClassifier().isEmpty() ? "" : ":" + getClassifier())
-      + ":" + getVersion();
+    return artifact.getGroupId() + ":" + artifact.getArtifactId()
+      + ":" + artifact.getExtension()
+      + (artifact.getClassifier().isEmpty() ? "" : ":" + artifact.getClassifier())
+      + ":" + artifact.getVersion();
   }
 
   @Override

--- a/stack-manager/src/main/java/io/vertx/stack/model/Artifact.java
+++ b/stack-manager/src/main/java/io/vertx/stack/model/Artifact.java
@@ -1,0 +1,153 @@
+package io.vertx.stack.model;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.aether.artifact.AbstractArtifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+
+import java.io.File;
+import java.util.*;
+
+public class Artifact extends AbstractArtifact {
+
+  private org.eclipse.aether.artifact.Artifact internal;
+  private HashSet<Artifact> via;
+  private static final Map<String, Artifact> globalArtifacts = new HashMap<>();
+
+  /**
+   * Use {@link #artifact(String)} or {@link #artifact(String, Artifact...)}.
+   */
+  private Artifact() {
+    // use static artifact(String) or artifact(String, Artifact...) methods
+  }
+
+  private Artifact(String coordinates, Artifact... via) {
+    this(new DefaultArtifact(coordinates), via);
+  }
+
+  private Artifact(org.eclipse.aether.artifact.Artifact fromArtifact, Artifact... via) {
+    internal = fromArtifact;
+    this.via = new HashSet<>(Arrays.asList(via));
+  }
+
+  public static Artifact artifact(String coordinates) {
+    return artifact(coordinates, new Artifact[]{});
+  }
+
+  public static Artifact artifact(String groupId, String artifactId, String classifier, String extension, String version, Artifact... via) {
+    return artifact(groupId + ":" + artifactId + ":" + extension + ":" + classifier + ":" + version, via);
+  }
+
+  public static Artifact artifact(String groupId, String artifactId, String extension, String version, Artifact... via) {
+    return artifact(groupId + ":" + artifactId + ":" + extension + ":" + version, via);
+  }
+
+  public static Artifact artifact(String coordinates, Artifact... via) {
+    return globalArtifacts.merge(coordinates, new Artifact(coordinates, via), (a1, a2) -> a1.addVia(a2.via));
+  }
+
+  /**
+   * Add more artifacts pointing to this.
+   */
+  public void addVia(Artifact... moreVia) {
+    addVia(Arrays.asList(moreVia));
+  }
+
+  /**
+   * Add more artifacts pointing to this.
+   */
+  public Artifact addVia(Collection<Artifact> moreVia) {
+    this.via.addAll(moreVia);
+    return this;
+  }
+
+  /**
+   * Renders the chain of artifacts that led to this artifact as String.
+   */
+  public static String renderChain(Artifact fromArtifact) {
+    return renderChain(fromArtifact, 0, new ArrayList<>());
+  }
+
+  private static String renderChain(Artifact fromArtifact, int level, List<String> acc) {
+    Optional<Artifact> maybeVia = fromArtifact.via.stream().findFirst();
+    if (maybeVia.isPresent()) {
+      Artifact via = maybeVia.get();
+      acc.add(0, fromArtifact.getCoordinates());
+      return renderChain(via, level + 1, acc);
+    } else {
+      StringBuilder chainBuilder = new StringBuilder(fromArtifact.getCoordinates());
+      for (int i = 0; i < acc.size(); i++) {
+        String indent = StringUtils.repeat("\t", i + 1);
+        chainBuilder
+          .append("\n")
+          .append(indent).append("\\-- ").append(acc.get(i));
+      }
+      return chainBuilder.toString();
+    }
+  }
+
+  @Override
+  public String getGroupId() {
+    return internal.getGroupId();
+  }
+
+  @Override
+  public String getArtifactId() {
+    return internal.getArtifactId();
+  }
+
+  @Override
+  public String getVersion() {
+    return internal.getVersion();
+  }
+
+  @Override
+  public String getClassifier() {
+    return internal.getClassifier();
+  }
+
+  @Override
+  public String getExtension() {
+    return internal.getExtension();
+  }
+
+  /**
+   * @return the artifact coordinates in the form {@code <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>}
+   */
+  public String getCoordinates() {
+    // <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>
+    return getGroupId() + ":" + getArtifactId()
+      + ":" + getExtension()
+      + (getClassifier().isEmpty() ? "" : ":" + getClassifier())
+      + ":" + getVersion();
+  }
+
+  @Override
+  public Artifact setFile(File file) {
+    internal = internal.setFile(file);
+    return this;
+  }
+
+  @Override
+  public File getFile() {
+    return internal.getFile();
+  }
+
+  @Override
+  public Map<String, String> getProperties() {
+    return internal.getProperties();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    Artifact artifact = (Artifact) o;
+    return Objects.equals(internal, artifact.internal) && Objects.equals(via, artifact.via);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), internal, via);
+  }
+}

--- a/stack-manager/src/main/java/io/vertx/stack/model/DependencyConflictException.java
+++ b/stack-manager/src/main/java/io/vertx/stack/model/DependencyConflictException.java
@@ -29,7 +29,7 @@ public class DependencyConflictException extends RuntimeException {
   private final String version;
   private final List<String> trace;
   private final String conflictingDependency;
-  private final String conflictingVersion;
+  private final Artifact conflictingArtifact;
 
   /**
    * Creates a {@link DependencyConflictException}.
@@ -37,14 +37,14 @@ public class DependencyConflictException extends RuntimeException {
    * @param artifact      the artifact
    * @param version the current version
    * @param conflictingDependency    the conflicting dependency
-   * @param conflictingVersion  the other version
+   * @param conflictingArtifact  the conflicting {@link Artifact}
    */
-  public DependencyConflictException(String artifact, String version, List<String> trace, String conflictingDependency, String conflictingVersion) {
+  public DependencyConflictException(String artifact, String version, List<String> trace, String conflictingDependency, Artifact conflictingArtifact) {
     this.artifact = artifact;
     this.version = version;
     this.trace = trace;
     this.conflictingDependency = conflictingDependency;
-    this.conflictingVersion = conflictingVersion;
+    this.conflictingArtifact = conflictingArtifact;
   }
 
   /**
@@ -55,8 +55,12 @@ public class DependencyConflictException extends RuntimeException {
    */
   @Override
   public String getMessage() {
-    return "Conflict detected for artifact " + artifact + " - version " + version + " was already selected " +
+
+    return "Conflict detected for artifact " + artifact + " - version " + version + " was already selected" +
       " by " + trace +
-      " while " + conflictingDependency + " depends on version " + conflictingVersion;
+      " while " + conflictingDependency + " depends on version " + conflictingArtifact.getVersion() +
+      " - see the following chain:\n" +
+      Artifact.renderChain(conflictingArtifact);
   }
+
 }

--- a/stack-manager/src/main/java/io/vertx/stack/model/StackResolution.java
+++ b/stack-manager/src/main/java/io/vertx/stack/model/StackResolution.java
@@ -173,7 +173,7 @@ public class StackResolution {
       // artifacts = cache.get(dependency.getGACV(), dependency.getResolutionOptions());
       if (list == null || list.isEmpty()) {
         // list = resolver.resolve(dependency.getGACV(), dependency.getResolutionOptions());
-        list = resolver.resolveTree(dependency.getGACV(), dependency.getResolutionOptions());
+        list = resolver.resolve(dependency.getGACV(), dependency.getResolutionOptions());
         cache.put(dependency.getGACV(), dependency.getResolutionOptions(), list);
         cache.writeCacheOnFile();
       } else {

--- a/stack-manager/src/main/java/io/vertx/stack/model/StackResolution.java
+++ b/stack-manager/src/main/java/io/vertx/stack/model/StackResolution.java
@@ -26,7 +26,6 @@ import org.eclipse.aether.artifact.Artifact;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -54,7 +53,7 @@ public class StackResolution {
   private final StackResolutionOptions options;
   private Resolver resolver;
 
-  private Cache cache;
+  private final Cache cache;
 
   /**
    * Creates an instance of {@link StackResolution}.
@@ -168,11 +167,13 @@ public class StackResolution {
   }
 
   private void resolve(Dependency dependency) {
-    List<Artifact> list;
+    List<io.vertx.stack.model.Artifact> list;
     if (dependency.isIncluded()) {
       list = cache.get(dependency.getGACV(), dependency.getResolutionOptions());
+      // artifacts = cache.get(dependency.getGACV(), dependency.getResolutionOptions());
       if (list == null || list.isEmpty()) {
-        list = resolver.resolve(dependency.getGACV(), dependency.getResolutionOptions());
+        // list = resolver.resolve(dependency.getGACV(), dependency.getResolutionOptions());
+        list = resolver.resolveTree(dependency.getGACV(), dependency.getResolutionOptions());
         cache.put(dependency.getGACV(), dependency.getResolutionOptions(), list);
         cache.writeCacheOnFile();
       } else {
@@ -183,7 +184,7 @@ public class StackResolution {
     }
 
     if (list == null || list.isEmpty()) {
-      throw new IllegalArgumentException("Cannot resolve " + dependency.toString());
+      throw new IllegalArgumentException("Cannot resolve " + dependency);
     }
 
     LOGGER.debug("Artifacts resolved for " + dependency.getGACV() + " : "
@@ -198,7 +199,7 @@ public class StackResolution {
       } else {
         List<String> trace = traces.get(gaec + ":" + version);
         if (options.isFailOnConflicts()) {
-          throw new DependencyConflictException(gaec, version, trace, dependency.getGACV(), artifact.getBaseVersion());
+          throw new DependencyConflictException(gaec, version, trace, dependency.getGACV(), artifact);
         }
       }
       addSelectedArtifact(dependency, artifact, version);
@@ -233,7 +234,7 @@ public class StackResolution {
     return artifact.getGroupId()
       + ":" + artifact.getArtifactId()
       + ":" + artifact.getExtension()
-      + (artifact.getClassifier() != null && artifact.getClassifier().length() > 0
+      + (artifact.getClassifier() != null && !artifact.getClassifier().isEmpty()
       ? ":" + artifact.getClassifier() : "");
   }
 
@@ -247,7 +248,7 @@ public class StackResolution {
   public static class ResolvedArtifact {
     private Artifact artifact;
     private String selectedVersion;
-    private Set<String> usages = new LinkedHashSet<>();
+    private final Set<String> usages = new LinkedHashSet<>();
 
     public Artifact getArtifact() {
       return artifact;

--- a/stack-manager/src/main/java/io/vertx/stack/resolver/Resolver.java
+++ b/stack-manager/src/main/java/io/vertx/stack/resolver/Resolver.java
@@ -37,6 +37,8 @@ public interface Resolver {
    */
   List<Artifact> resolve(String dependency, ResolutionOptions options);
 
+  List<io.vertx.stack.model.Artifact> resolveTree(String dependency, ResolutionOptions options);
+
   /**
    * Creates a {@link Resolver} using the default implementation and default options.
    *

--- a/stack-manager/src/main/java/io/vertx/stack/resolver/Resolver.java
+++ b/stack-manager/src/main/java/io/vertx/stack/resolver/Resolver.java
@@ -16,7 +16,8 @@
 
 package io.vertx.stack.resolver;
 
-import org.eclipse.aether.artifact.Artifact;
+
+import io.vertx.stack.model.Artifact;
 
 import java.util.List;
 
@@ -36,8 +37,6 @@ public interface Resolver {
    * not resolved. The first artifact of the list if the artifact for the given dependency.
    */
   List<Artifact> resolve(String dependency, ResolutionOptions options);
-
-  List<io.vertx.stack.model.Artifact> resolveTree(String dependency, ResolutionOptions options);
 
   /**
    * Creates a {@link Resolver} using the default implementation and default options.

--- a/stack-manager/src/main/java/io/vertx/stack/resolver/ResolverImpl.java
+++ b/stack-manager/src/main/java/io/vertx/stack/resolver/ResolverImpl.java
@@ -340,12 +340,12 @@ public class ResolverImpl implements Resolver {
 
   @Override
   public List<io.vertx.stack.model.Artifact> resolveTree(String gacv, ResolutionOptions options) {
-    io.vertx.stack.model.Artifact rootArtifact = new io.vertx.stack.model.Artifact(gacv);
-    DependencyNode root = resolveTree(rootArtifact, options.isWithTransitive(), options.getExclusions());
+    DependencyNode root = resolveTree(new io.vertx.stack.model.Artifact(gacv), options.isWithTransitive(), options.getExclusions());
     List<Exclusion> exclusions = Stream.concat(Stream.of(root), root.getChildren().stream())
       .map(DependencyNode::getDependency)
       .flatMap(dependency -> dependency.getExclusions().stream())
       .collect(Collectors.toList());
+    io.vertx.stack.model.Artifact rootArtifact = new io.vertx.stack.model.Artifact(root.getArtifact(), null);
     return Stream
       .concat(Stream.of(rootArtifact), toArtifacts(root, rootArtifact, exclusions))
       .collect(Collectors.toList());

--- a/stack-manager/src/main/java/io/vertx/stack/resolver/ResolverImpl.java
+++ b/stack-manager/src/main/java/io/vertx/stack/resolver/ResolverImpl.java
@@ -235,7 +235,6 @@ public class ResolverImpl implements Resolver {
     }
   }
 
-
   private static Authentication extractAuth(URL url) {
     String userInfo = url.getUserInfo();
     if (userInfo != null) {
@@ -341,20 +340,30 @@ public class ResolverImpl implements Resolver {
 
   @Override
   public List<io.vertx.stack.model.Artifact> resolveTree(String gacv, ResolutionOptions options) {
-    io.vertx.stack.model.Artifact rootArtifact = io.vertx.stack.model.Artifact.artifact(gacv);
+    io.vertx.stack.model.Artifact rootArtifact = new io.vertx.stack.model.Artifact(gacv);
     DependencyNode root = resolveTree(rootArtifact, options.isWithTransitive(), options.getExclusions());
+    List<Exclusion> exclusions = Stream.concat(Stream.of(root), root.getChildren().stream())
+      .map(DependencyNode::getDependency)
+      .flatMap(dependency -> dependency.getExclusions().stream())
+      .collect(Collectors.toList());
     return Stream
-      .concat(Stream.of(rootArtifact), toArtifacts(root))
+      .concat(Stream.of(rootArtifact), toArtifacts(root, rootArtifact, exclusions))
       .collect(Collectors.toList());
   }
 
-  private Stream<io.vertx.stack.model.Artifact> toArtifacts(DependencyNode dependencyNode) {
-    io.vertx.stack.model.Artifact rootArtifact = io.vertx.stack.model.Artifact.artifact(dependencyNode.getArtifact());
+  private Stream<io.vertx.stack.model.Artifact> toArtifacts(DependencyNode dependencyNode, io.vertx.stack.model.Artifact rootArtifact, List<Exclusion> exclusions) {
     return dependencyNode.getChildren().stream()
+      // remove optional dependencies
+      .filter(childNode -> !childNode.getDependency().isOptional())
+      // remove excluded dependencies
+      .filter(childNode -> exclusions.stream().noneMatch(exclusion ->
+        exclusion.getGroupId().equals(childNode.getArtifact().getGroupId())
+          && exclusion.getArtifactId().equals(childNode.getArtifact().getArtifactId())))
+      // remove provided dependencies and transitive dependencies of provided dependencies
+      .filter(childNode -> childNode.getDependency().getScope().equalsIgnoreCase("compile"))
       .flatMap(childNode -> {
-        io.vertx.stack.model.Artifact childArtifact = io.vertx.stack.model.Artifact.artifact(childNode.getArtifact());
-        childArtifact.addVia(rootArtifact);
-        return Stream.concat(Stream.of(childArtifact), toArtifacts(childNode));
+        io.vertx.stack.model.Artifact childArtifact = new io.vertx.stack.model.Artifact(childNode.getArtifact(), rootArtifact);
+        return Stream.concat(Stream.of(childArtifact), toArtifacts(childNode, childArtifact, exclusions));
       });
   }
 

--- a/stack-manager/src/main/java/io/vertx/stack/utils/Cache.java
+++ b/stack-manager/src/main/java/io/vertx/stack/utils/Cache.java
@@ -46,10 +46,10 @@ public class Cache {
       JsonNode node = p.getCodec().readTree(p);
       Artifact artifact;
       if (!node.get("classifier").asText().isEmpty()) {
-        artifact = Artifact.artifact(node.get("groupId").asText(), node.get("artifactId").asText(),
+        artifact = new Artifact(node.get("groupId").asText(), node.get("artifactId").asText(),
             node.get("classifier").asText(), node.get("extension").asText(), node.get("version").asText());
       } else {
-        artifact = Artifact.artifact(node.get("groupId").asText(), node.get("artifactId").asText(),
+        artifact = new Artifact(node.get("groupId").asText(), node.get("artifactId").asText(),
             node.get("extension").asText(), node.get("version").asText());
       }
       artifact = artifact.setFile(new File(node.get("file").asText()));

--- a/stack-manager/src/main/java/io/vertx/stack/utils/Cache.java
+++ b/stack-manager/src/main/java/io/vertx/stack/utils/Cache.java
@@ -21,9 +21,8 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.stack.model.Artifact;
 import io.vertx.stack.resolver.ResolutionOptions;
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.DefaultArtifact;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,11 +45,11 @@ public class Cache {
     public Artifact deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
       JsonNode node = p.getCodec().readTree(p);
       Artifact artifact;
-      if (node.get("classifier") != null) {
-        artifact = new DefaultArtifact(node.get("groupId").asText(), node.get("artifactId").asText(),
+      if (!node.get("classifier").asText().isEmpty()) {
+        artifact = Artifact.artifact(node.get("groupId").asText(), node.get("artifactId").asText(),
             node.get("classifier").asText(), node.get("extension").asText(), node.get("version").asText());
       } else {
-        artifact = new DefaultArtifact(node.get("groupId").asText(), node.get("artifactId").asText(),
+        artifact = Artifact.artifact(node.get("groupId").asText(), node.get("artifactId").asText(),
             node.get("extension").asText(), node.get("version").asText());
       }
       artifact = artifact.setFile(new File(node.get("file").asText()));
@@ -135,8 +134,7 @@ public class Cache {
       return false;
     }
 
-    if (entry.getArtifacts().stream().filter(artifact -> !artifact.getFile().isFile())
-        .findAny().isPresent()) {
+    if (entry.getArtifacts().stream().anyMatch(artifact -> !artifact.getFile().isFile())) {
       return false;
     }
 

--- a/stack-manager/src/main/java/io/vertx/stack/utils/Cache.java
+++ b/stack-manager/src/main/java/io/vertx/stack/utils/Cache.java
@@ -40,22 +40,33 @@ public class Cache {
 
   // We don't use the MAPPEr from vert.x because it requires some tuning.
   private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(
-      new SimpleModule("artifact-module").addDeserializer(Artifact.class, new JsonDeserializer<Artifact>() {
-    @Override
-    public Artifact deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-      JsonNode node = p.getCodec().readTree(p);
-      Artifact artifact;
-      if (!node.get("classifier").asText().isEmpty()) {
-        artifact = new Artifact(node.get("groupId").asText(), node.get("artifactId").asText(),
-            node.get("classifier").asText(), node.get("extension").asText(), node.get("version").asText());
-      } else {
-        artifact = new Artifact(node.get("groupId").asText(), node.get("artifactId").asText(),
-            node.get("extension").asText(), node.get("version").asText());
+    new SimpleModule("artifact-module").addDeserializer(Artifact.class, new JsonDeserializer<Artifact>() {
+      @Override
+      public Artifact deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonNode node = p.getCodec().readTree(p);
+        return fromJsonNode(node);
       }
-      artifact = artifact.setFile(new File(node.get("file").asText()));
-      return artifact;
-    }
-  }));
+
+      private Artifact fromJsonNode(JsonNode node) {
+        JsonNode viaNode = node.get("via");
+        Artifact via;
+        if (viaNode == null || viaNode.asText().equalsIgnoreCase("null")) {
+          via = null;
+        } else {
+          via = fromJsonNode(viaNode);
+        }
+
+        Artifact artifact;
+        if (!node.get("classifier").asText().isEmpty()) {
+          artifact = new Artifact(node.get("groupId").asText(), node.get("artifactId").asText(),
+            node.get("classifier").asText(), node.get("extension").asText(), node.get("version").asText(), via);
+        } else {
+          artifact = new Artifact(node.get("groupId").asText(), node.get("artifactId").asText(),
+            node.get("extension").asText(), node.get("version").asText(), via);
+        }
+        return artifact.setFile(new File(node.get("file").asText()));
+      }
+    }));
 
   private final boolean disabled;
   private final boolean disabledForSnapshot;
@@ -82,7 +93,7 @@ public class Cache {
     if (!disabled && this.cacheFile != null && this.cacheFile.isFile()) {
       LOGGER.info("Loading resolver cache from " + this.cacheFile.getAbsolutePath());
       JavaType type = MAPPER.getTypeFactory().
-          constructCollectionType(List.class, CacheEntry.class);
+        constructCollectionType(List.class, CacheEntry.class);
       try {
         cache.addAll(MAPPER.readValue(this.cacheFile, type));
       } catch (IOException e) {
@@ -163,16 +174,16 @@ public class Cache {
     } else {
       CacheEntry cached = new CacheEntry();
       cached.setArtifacts(list)
-          .setGacv(gacv)
-          .setOptions(resolutionOptions)
-          .setInsertionTime(System.currentTimeMillis());
+        .setGacv(gacv)
+        .setOptions(resolutionOptions)
+        .setInsertionTime(System.currentTimeMillis());
       cache.add(cached);
     }
   }
 
   public Optional<CacheEntry> find(String gacv, ResolutionOptions options) {
     return cache.stream().filter(entry -> entry.gacv.equals(gacv)
-        && entry.options.equals(options)).findFirst();
+      && entry.options.equals(options)).findFirst();
   }
 
   public int size() {

--- a/stack-manager/src/test/java/io/vertx/stack/resolver/ResolverTest.java
+++ b/stack-manager/src/test/java/io/vertx/stack/resolver/ResolverTest.java
@@ -17,11 +17,11 @@
 package io.vertx.stack.resolver;
 
 
+import io.vertx.stack.model.Artifact;
 import io.vertx.stack.utils.FileUtils;
 import io.vertx.stack.utils.LocalArtifact;
 import io.vertx.stack.utils.LocalDependency;
 import io.vertx.stack.utils.LocalRepoBuilder;
-import org.eclipse.aether.artifact.Artifact;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,7 +40,7 @@ public class ResolverTest {
 
   public final static File LOCAL = new File(ROOT, "fake-local-maven-repo");
 
-  private Resolver resolver = Resolver.create(new ResolverOptions().setLocalRepository(LOCAL.getAbsolutePath()));
+  private final Resolver resolver = Resolver.create(new ResolverOptions().setLocalRepository(LOCAL.getAbsolutePath()));
 
   @Before
   public void setUp() {
@@ -105,7 +105,7 @@ public class ResolverTest {
 
   @Test
   public void testResolutionWhenADependencyIsPresentTwiceInTheGraph() {
-    
+
     new LocalRepoBuilder(LOCAL)
         .addArtifact(new LocalArtifact("com.acme", "acme-api", "1.0").generateMainArtifact())
         .addArtifact(new LocalArtifact("com.acme", "acme-lib", "1.0")
@@ -128,7 +128,7 @@ public class ResolverTest {
 
   @Test
   public void testResolutionWhenADependencyIsPresentTwiceInTheGraphWithDifferentScope() {
-    
+
     new LocalRepoBuilder(LOCAL)
         .addArtifact(new LocalArtifact("com.acme", "acme-api", "1.0").generateMainArtifact())
         .addArtifact(new LocalArtifact("com.acme", "acme-lib", "1.0")
@@ -151,7 +151,7 @@ public class ResolverTest {
 
   @Test
   public void testResolutionWhenADependencyIsPresentTwiceInTheGraphWithVersion() {
-    
+
     new LocalRepoBuilder(LOCAL)
         .addArtifact(new LocalArtifact("com.acme", "acme-api", "1.0").generateMainArtifact())
         .addArtifact(new LocalArtifact("com.acme", "acme-api", "1.1").generateMainArtifact())
@@ -174,7 +174,7 @@ public class ResolverTest {
 
   @Test
   public void testResolutionWhenADependencyIsPresentTwiceInTheGraphWithVersionInverted() {
-    
+
     new LocalRepoBuilder(LOCAL)
         .addArtifact(new LocalArtifact("com.acme", "acme-api", "1.0").generateMainArtifact())
         .addArtifact(new LocalArtifact("com.acme", "acme-api", "1.1").generateMainArtifact())

--- a/stack-manager/src/test/java/io/vertx/stack/utils/CacheTest.java
+++ b/stack-manager/src/test/java/io/vertx/stack/utils/CacheTest.java
@@ -16,9 +16,8 @@
 
 package io.vertx.stack.utils;
 
+import io.vertx.stack.model.Artifact;
 import io.vertx.stack.resolver.ResolutionOptions;
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -61,14 +60,14 @@ public class CacheTest {
   }
 
   @Test
-  public void testCachingOfReleaseAndUpdate() throws IOException {
+  public void testCachingOfReleaseAndUpdate() {
     String gacv = "org.acme:acme:jar:1.0";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
-    Artifact artifact2 = new DefaultArtifact("org.acme:acme-dep:jar:1.0").setFile(TEMP_FILE);
+    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
+    Artifact artifact2 = Artifact.artifact("org.acme:acme-dep:jar:1.0").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -84,14 +83,14 @@ public class CacheTest {
   }
 
   @Test
-  public void testCachingOfSnapshotAndUpdate() throws IOException {
+  public void testCachingOfSnapshotAndUpdate() {
     String gacv = "org.acme:acme:jar:1.0-SNAPSHOT";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
-    Artifact artifact2 = new DefaultArtifact("org.acme:acme-dep:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
+    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
+    Artifact artifact2 = Artifact.artifact("org.acme:acme-dep:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -116,7 +115,7 @@ public class CacheTest {
     assertThat(list).isNull();
 
     File file = File.createTempFile("acme", ".jar");
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0").setFile(file);
+    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0").setFile(file);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -124,14 +123,14 @@ public class CacheTest {
   }
 
   @Test
-  public void testCacheDisabledForSnapshots() throws IOException {
+  public void testCacheDisabledForSnapshots() {
     String gacv = "org.acme:acme:jar:1.0-SNAPSHOT";
     cache = new Cache(false, true, cacheFile);
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
+    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -139,13 +138,13 @@ public class CacheTest {
   }
 
   @Test
-  public void testWithInvalidArtifact() throws IOException {
+  public void testWithInvalidArtifact() {
     String gacv = "org.acme:acme:jar:1.0";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0").setFile(new File("does not exist.jar"));
+    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0").setFile(new File("does not exist.jar"));
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -153,7 +152,7 @@ public class CacheTest {
   }
 
   @Test
-  public void testWithEmptyResolution() throws IOException {
+  public void testWithEmptyResolution() {
     String gacv = "org.acme:acme:jar:1.0";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
@@ -164,13 +163,13 @@ public class CacheTest {
   }
 
   @Test
-  public void testCacheReloading() throws IOException {
+  public void testCacheReloading() {
     String gacv = "org.acme:acme:jar:1.0";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
+    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -184,13 +183,13 @@ public class CacheTest {
   }
 
   @Test
-  public void testSnapshotEviction() throws IOException {
+  public void testSnapshotEviction() {
     String gacv = "org.acme:acme:jar:1.0-SNAPSHOT";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
+    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -204,13 +203,13 @@ public class CacheTest {
   }
 
   @Test
-  public void testNonSnapshotEviction() throws IOException {
+  public void testNonSnapshotEviction() {
     String gacv = "org.acme:acme:jar:1.0-SNAPSHOT";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
+    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -224,13 +223,13 @@ public class CacheTest {
   }
 
   @Test
-  public void testCachingUsingDifferentResolutionOption() throws IOException {
+  public void testCachingUsingDifferentResolutionOption() {
     String gacv = "org.acme:acme:jar:1.0";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
+    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);

--- a/stack-manager/src/test/java/io/vertx/stack/utils/CacheTest.java
+++ b/stack-manager/src/test/java/io/vertx/stack/utils/CacheTest.java
@@ -66,8 +66,8 @@ public class CacheTest {
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
-    Artifact artifact2 = Artifact.artifact("org.acme:acme-dep:jar:1.0").setFile(TEMP_FILE);
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
+    Artifact artifact2 = new Artifact("org.acme:acme-dep:jar:1.0").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -89,8 +89,8 @@ public class CacheTest {
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
-    Artifact artifact2 = Artifact.artifact("org.acme:acme-dep:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
+    Artifact artifact2 = new Artifact("org.acme:acme-dep:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -115,7 +115,7 @@ public class CacheTest {
     assertThat(list).isNull();
 
     File file = File.createTempFile("acme", ".jar");
-    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0").setFile(file);
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0").setFile(file);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -130,7 +130,7 @@ public class CacheTest {
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -144,7 +144,7 @@ public class CacheTest {
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0").setFile(new File("does not exist.jar"));
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0").setFile(new File("does not exist.jar"));
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -169,7 +169,7 @@ public class CacheTest {
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -189,7 +189,7 @@ public class CacheTest {
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -209,7 +209,7 @@ public class CacheTest {
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -229,7 +229,7 @@ public class CacheTest {
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = Artifact.artifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);


### PR DESCRIPTION
Motivation:

See #73 

`VertxStacksTest` will print something like the following when a `DependencyConflictException` occurs:

Note: In this case the conflicting artifacts `io.vertx:vertx-web-templ-pug:4.4.8` and `io.vertx:vertx-lang-kotlin:4.4.8` were chosen for the stack.

```
Conflict detected for artifact org.jetbrains:annotations:jar - version 15.0 was already selected by [io.vertx:vertx-web-templ-pug:jar:4.4.8] while io.vertx:vertx-lang-kotlin:jar:4.4.8 depends on version 13.0 - see the following chain:
io.vertx:vertx-lang-kotlin:jar:4.4.8
    \-- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.7.21
        \-- org.jetbrains.kotlin:kotlin-stdlib:jar:1.7.21
            \-- org.jetbrains:annotations:jar:13.0
```