### PR TITLE
Detailed dependency path for DependencyConflictException (4.x)

### DIFF
--- a/stack-manager/src/main/java/io/vertx/stack/model/Artifact.java
+++ b/stack-manager/src/main/java/io/vertx/stack/model/Artifact.java
@@ -1,0 +1,160 @@
+package io.vertx.stack.model;
+
+import org.eclipse.aether.artifact.AbstractArtifact;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class Artifact extends AbstractArtifact {
+
+  private final String groupId;
+  private final String artifactId;
+  private final String version;
+  private final String classifier;
+  private final String extension;
+  private final File file;
+  private final Map<String, String> properties;
+  private final Artifact via;
+  private static final Pattern coordinatesPattern =
+    Pattern.compile("([^: ]+):([^: ]+)(:([^: ]*)(:([^: ]+))?)?:([^: ]+)");
+
+  public Artifact(String coordinates) {
+    this(coordinates, null);
+  }
+
+  public Artifact(String groupId, String artifactId, String classifier, String extension, String version, Artifact via) {
+    this(groupId + ":" + artifactId + ":" + extension + ":" + classifier + ":" + version, via);
+  }
+
+  public Artifact(String groupId, String artifactId, String extension, String version, Artifact via) {
+    this(groupId + ":" + artifactId + ":" + extension + ":" + version, via);
+  }
+
+  public Artifact(org.eclipse.aether.artifact.Artifact fromArtifact, Artifact via) {
+    this(coordinates(fromArtifact), via, fromArtifact.getFile(), fromArtifact.getProperties());
+  }
+
+  public Artifact(String coordinates, Artifact viaArtifact) {
+    this(coordinates, viaArtifact, null, new HashMap<>());
+  }
+
+  private Artifact(String coordinates, Artifact viaArtifact, File artifactFile, Map<String, String> props) {
+    Matcher m = coordinatesPattern.matcher(coordinates);
+
+    if (!m.matches()) {
+      throw new IllegalArgumentException("Bad artifact coordinates " + coordinates
+        + ", expected format is <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>");
+    }
+
+    groupId = m.group(1);
+    artifactId = m.group(2);
+    extension = defaultIfEmpty(m.group(4), "jar");
+    classifier = defaultIfEmpty(m.group(6), "");
+    version = m.group(7);
+    file = artifactFile;
+    properties = copyProperties(props);
+    via = viaArtifact;
+  }
+
+  private String defaultIfEmpty(String value, String defaultValue) {
+    if (value == null || value.trim().isEmpty()) {
+      return defaultValue;
+    } else {
+      return value;
+    }
+  }
+
+  @Override
+  public String getGroupId() {
+    return groupId;
+  }
+
+  @Override
+  public String getArtifactId() {
+    return artifactId;
+  }
+
+  @Override
+  public String getVersion() {
+    return version;
+  }
+
+  @Override
+  public String getClassifier() {
+    return classifier;
+  }
+
+  @Override
+  public String getExtension() {
+    return extension;
+  }
+
+  @Override
+  public Artifact setFile(File file) {
+    if (Objects.equals(this.file, file)) {
+      return this;
+    } else {
+      return new Artifact(coordinates(this), via, file, properties);
+    }
+  }
+
+  @Override
+  public File getFile() {
+    return file;
+  }
+
+  @Override
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  @Override
+  public Artifact setProperties(Map<String, String> properties) {
+    if (Objects.equals(this.properties, properties)) {
+      return this;
+    } else {
+      return new Artifact(coordinates(this), via, file, copyProperties(properties));
+    }
+  }
+
+  public Artifact getVia() {
+    return via;
+  }
+
+  public String getCoordinates() {
+    return coordinates(this);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    Artifact artifact = (Artifact) o;
+    return Objects.equals(groupId, artifact.groupId)
+      && Objects.equals(artifactId, artifact.artifactId)
+      && Objects.equals(version, artifact.version)
+      && Objects.equals(classifier, artifact.classifier)
+      && Objects.equals(extension, artifact.extension)
+      && Objects.equals(file, artifact.file)
+      && Objects.equals(properties, artifact.properties)
+      && Objects.equals(via, artifact.via);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), groupId, artifactId, version, classifier, extension, file, properties, via);
+  }
+
+  private static String coordinates(org.eclipse.aether.artifact.Artifact artifact) {
+    // <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>
+    return artifact.getGroupId() + ":" + artifact.getArtifactId()
+      + ":" + artifact.getExtension()
+      + (artifact.getClassifier().isEmpty() ? "" : ":" + artifact.getClassifier())
+      + ":" + artifact.getVersion();
+  }
+}

--- a/stack-manager/src/main/java/io/vertx/stack/resolver/Resolver.java
+++ b/stack-manager/src/main/java/io/vertx/stack/resolver/Resolver.java
@@ -16,7 +16,8 @@
 
 package io.vertx.stack.resolver;
 
-import org.eclipse.aether.artifact.Artifact;
+
+import io.vertx.stack.model.Artifact;
 
 import java.util.List;
 

--- a/stack-manager/src/test/java/io/vertx/stack/resolver/ResolverTest.java
+++ b/stack-manager/src/test/java/io/vertx/stack/resolver/ResolverTest.java
@@ -17,11 +17,11 @@
 package io.vertx.stack.resolver;
 
 
+import io.vertx.stack.model.Artifact;
 import io.vertx.stack.utils.FileUtils;
 import io.vertx.stack.utils.LocalArtifact;
 import io.vertx.stack.utils.LocalDependency;
 import io.vertx.stack.utils.LocalRepoBuilder;
-import org.eclipse.aether.artifact.Artifact;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,7 +40,7 @@ public class ResolverTest {
 
   public final static File LOCAL = new File(ROOT, "fake-local-maven-repo");
 
-  private Resolver resolver = Resolver.create(new ResolverOptions().setLocalRepository(LOCAL.getAbsolutePath()));
+  private final Resolver resolver = Resolver.create(new ResolverOptions().setLocalRepository(LOCAL.getAbsolutePath()));
 
   @Before
   public void setUp() {
@@ -105,7 +105,7 @@ public class ResolverTest {
 
   @Test
   public void testResolutionWhenADependencyIsPresentTwiceInTheGraph() {
-    
+
     new LocalRepoBuilder(LOCAL)
         .addArtifact(new LocalArtifact("com.acme", "acme-api", "1.0").generateMainArtifact())
         .addArtifact(new LocalArtifact("com.acme", "acme-lib", "1.0")
@@ -128,7 +128,7 @@ public class ResolverTest {
 
   @Test
   public void testResolutionWhenADependencyIsPresentTwiceInTheGraphWithDifferentScope() {
-    
+
     new LocalRepoBuilder(LOCAL)
         .addArtifact(new LocalArtifact("com.acme", "acme-api", "1.0").generateMainArtifact())
         .addArtifact(new LocalArtifact("com.acme", "acme-lib", "1.0")
@@ -151,7 +151,7 @@ public class ResolverTest {
 
   @Test
   public void testResolutionWhenADependencyIsPresentTwiceInTheGraphWithVersion() {
-    
+
     new LocalRepoBuilder(LOCAL)
         .addArtifact(new LocalArtifact("com.acme", "acme-api", "1.0").generateMainArtifact())
         .addArtifact(new LocalArtifact("com.acme", "acme-api", "1.1").generateMainArtifact())
@@ -174,7 +174,7 @@ public class ResolverTest {
 
   @Test
   public void testResolutionWhenADependencyIsPresentTwiceInTheGraphWithVersionInverted() {
-    
+
     new LocalRepoBuilder(LOCAL)
         .addArtifact(new LocalArtifact("com.acme", "acme-api", "1.0").generateMainArtifact())
         .addArtifact(new LocalArtifact("com.acme", "acme-api", "1.1").generateMainArtifact())

--- a/stack-manager/src/test/java/io/vertx/stack/utils/CacheTest.java
+++ b/stack-manager/src/test/java/io/vertx/stack/utils/CacheTest.java
@@ -16,14 +16,14 @@
 
 package io.vertx.stack.utils;
 
+import io.vertx.stack.model.Artifact;
 import io.vertx.stack.resolver.ResolutionOptions;
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -50,25 +50,24 @@ public class CacheTest {
   }
 
   @Before
-  public void setUp() {
+  public void setUp() throws IOException {
     cacheFile = new File("target/test-cache/cache.json");
     if (cacheFile.isFile()) {
-      cacheFile.delete();
+      Files.delete(cacheFile.toPath());
     }
 
     cache = new Cache(false, false, cacheFile);
-
   }
 
   @Test
-  public void testCachingOfReleaseAndUpdate() throws IOException {
+  public void testCachingOfReleaseAndUpdate() {
     String gacv = "org.acme:acme:jar:1.0";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
-    Artifact artifact2 = new DefaultArtifact("org.acme:acme-dep:jar:1.0").setFile(TEMP_FILE);
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
+    Artifact artifact2 = new Artifact("org.acme:acme-dep:jar:1.0").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -84,14 +83,14 @@ public class CacheTest {
   }
 
   @Test
-  public void testCachingOfSnapshotAndUpdate() throws IOException {
+  public void testCachingOfSnapshotAndUpdate() {
     String gacv = "org.acme:acme:jar:1.0-SNAPSHOT";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
-    Artifact artifact2 = new DefaultArtifact("org.acme:acme-dep:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
+    Artifact artifact2 = new Artifact("org.acme:acme-dep:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -116,7 +115,7 @@ public class CacheTest {
     assertThat(list).isNull();
 
     File file = File.createTempFile("acme", ".jar");
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0").setFile(file);
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0").setFile(file);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -124,14 +123,14 @@ public class CacheTest {
   }
 
   @Test
-  public void testCacheDisabledForSnapshots() throws IOException {
+  public void testCacheDisabledForSnapshots() {
     String gacv = "org.acme:acme:jar:1.0-SNAPSHOT";
     cache = new Cache(false, true, cacheFile);
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -139,13 +138,13 @@ public class CacheTest {
   }
 
   @Test
-  public void testWithInvalidArtifact() throws IOException {
+  public void testWithInvalidArtifact() {
     String gacv = "org.acme:acme:jar:1.0";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0").setFile(new File("does not exist.jar"));
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0").setFile(new File("does not exist.jar"));
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -153,7 +152,7 @@ public class CacheTest {
   }
 
   @Test
-  public void testWithEmptyResolution() throws IOException {
+  public void testWithEmptyResolution() {
     String gacv = "org.acme:acme:jar:1.0";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
@@ -164,13 +163,13 @@ public class CacheTest {
   }
 
   @Test
-  public void testCacheReloading() throws IOException {
+  public void testCacheReloading() {
     String gacv = "org.acme:acme:jar:1.0";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -184,19 +183,20 @@ public class CacheTest {
   }
 
   @Test
-  public void testSnapshotEviction() throws IOException {
+  public void testSnapshotEviction() {
     String gacv = "org.acme:acme:jar:1.0-SNAPSHOT";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
     assertThat(list).hasSize(1);
 
     Optional<Cache.CacheEntry> entry = cache.find(gacv, options);
+    assertThat(entry).isPresent();
     entry.get().setInsertionTime(System.currentTimeMillis() - 25 * 60 * 60 * 1000);
 
     list = cache.get(gacv, options);
@@ -204,19 +204,20 @@ public class CacheTest {
   }
 
   @Test
-  public void testNonSnapshotEviction() throws IOException {
+  public void testNonSnapshotEviction() {
     String gacv = "org.acme:acme:jar:1.0-SNAPSHOT";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0-SNAPSHOT").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
     assertThat(list).hasSize(1);
 
     Optional<Cache.CacheEntry> entry = cache.find(gacv, options);
+    assertThat(entry).isPresent();
     entry.get().setInsertionTime(System.currentTimeMillis() - 22 * 60 * 60 * 1000);
 
     list = cache.get(gacv, options);
@@ -224,13 +225,13 @@ public class CacheTest {
   }
 
   @Test
-  public void testCachingUsingDifferentResolutionOption() throws IOException {
+  public void testCachingUsingDifferentResolutionOption() {
     String gacv = "org.acme:acme:jar:1.0";
     ResolutionOptions options = new ResolutionOptions();
     List<Artifact> list = cache.get(gacv, options);
     assertThat(list).isNull();
 
-    Artifact artifact = new DefaultArtifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
+    Artifact artifact = new Artifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
 
     cache.put(gacv, options, Collections.singletonList(artifact));
     list = cache.get(gacv, options);
@@ -253,8 +254,21 @@ public class CacheTest {
     list = cache.get(gacv, options);
     assertThat(list).hasSize(1);
     assertThat(cache.size()).isEqualTo(3);
-
   }
 
+  @Test
+  public void testDeserializationOfViaArtifact() {
+    ResolutionOptions resolutionOptions = new ResolutionOptions();
+    Artifact root = new Artifact("org.acme:acme:jar:1.0").setFile(TEMP_FILE);
+    String gacv = "org.acme:transitive:jar:1.1";
+    Artifact transitive = new Artifact(gacv, root).setFile(TEMP_FILE);
+    cache.put(gacv, resolutionOptions, Collections.singletonList(transitive));
+    cache.writeCacheOnFile();
+
+    cache = new Cache(false, false, cacheFile);
+    List<Artifact> deserialized = cache.get(gacv, resolutionOptions);
+    assertThat(deserialized).hasSize(1);
+    assertThat(deserialized.get(0).getVia()).isEqualTo(root);
+  }
 
 }


### PR DESCRIPTION
Motivation:

See #73, back port of `main` branch for 4.x

`VertxStacksTest` will print something like the following when a `DependencyConflictException` occurs:

Note: In this case the conflicting artifacts `io.vertx:vertx-web-templ-pug:4.4.8` and `io.vertx:vertx-lang-kotlin:4.4.8` were chosen for the stack.

```
Conflict detected for artifact org.jetbrains:annotations:jar - version 15.0 was already selected by [io.vertx:vertx-web-templ-pug:jar:4.4.8] while io.vertx:vertx-lang-kotlin:jar:4.4.8 depends on version 13.0 - see the following chain:
io.vertx:vertx-lang-kotlin:jar:4.4.8
    \-- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.7.21
        \-- org.jetbrains.kotlin:kotlin-stdlib:jar:1.7.21
            \-- org.jetbrains:annotations:jar:13.0
```