### PR TITLE
Add spotless plugin and remove unused imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,18 @@
   </dependencyManagement>
 
   <build>
+    <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <java>
+            <removeUnusedImports />
+          </java>
+        </configuration>
+      </plugin>
+    </plugins>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/stack-manager/src/main/java/io/vertx/stack/command/ResolveCommand.java
+++ b/stack-manager/src/main/java/io/vertx/stack/command/ResolveCommand.java
@@ -16,19 +16,15 @@
 
 package io.vertx.stack.command;
 
-import io.vertx.core.cli.CLI;
 import io.vertx.core.cli.CLIException;
-import io.vertx.core.cli.CommandLine;
 import io.vertx.core.cli.annotations.*;
 import io.vertx.core.spi.launcher.DefaultCommand;
-import io.vertx.core.spi.launcher.ExecutionContext;
 import io.vertx.stack.model.Stack;
 import io.vertx.stack.model.StackResolution;
 import io.vertx.stack.model.StackResolutionOptions;
 import io.vertx.stack.utils.Home;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/stack-manager/src/test/java/io/vertx/stack/VertxStacksTest.java
+++ b/stack-manager/src/test/java/io/vertx/stack/VertxStacksTest.java
@@ -18,7 +18,6 @@ package io.vertx.stack;
 
 import com.jayway.awaitility.Awaitility;
 import io.vertx.core.impl.launcher.commands.VersionCommand;
-import io.vertx.stack.model.Dependency;
 import io.vertx.stack.model.Stack;
 import io.vertx.stack.model.StackResolution;
 import io.vertx.stack.model.StackResolutionOptions;


### PR DESCRIPTION
Added spotless plugin to remove unused imports. I have just added the goal of removing unused imports, this can be further extended to impose a code style, import order etc.

cc @vietj I believe this will help with checks. You can use goal = `spotless:apply` to remove unused imports now.